### PR TITLE
Make default sort selection by comment count (Top)

### DIFF
--- a/js/forum/src/components/DiscussionList.js
+++ b/js/forum/src/components/DiscussionList.js
@@ -112,8 +112,8 @@ export default class DiscussionList extends Component {
     if (this.props.params.q) {
       map.relevance = '';
     }
-    map.latest = '-lastTime';
     map.top = '-commentsCount';
+    map.latest = '-lastTime';
     map.newest = '-startTime';
     map.oldest = 'startTime';
 


### PR DESCRIPTION
Changed order of sort so that `map.top` is the first value. Committing to core directly as Tomas has indicated forums will be changed to another software.